### PR TITLE
Added a goroutine safe function

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ log.Printf("result = %s", result)
 
 ```
 
+# Goroutine Safe Function
+Use function HumanizeUsing if you need to generate human hashes from within multiple goroutines and you don't want to use the default word list or delimiter.
+
+```go
+
+input :=  []byte{96, 173, 141, 13, 135, 27, 96, 149, 128, 130, 151}
+
+// take the input and map it to 4 words from your own keyword list, using . as the word delimiter.
+result, _ := humanhash.HumanizeUsing(input, 4, myKeywordList, ".")
+
+```
+Refer to human_hash_test.go for a working example.
+
 # Sponsor
 
 This project was made possible by [Ninja Blocks](http://ninjablocks.com).

--- a/human_hash.go
+++ b/human_hash.go
@@ -131,3 +131,24 @@ func Compress(digest []byte, target int) ([]byte, error) {
 
 	return results, nil
 }
+
+// A version of Humanize which uses a supplied keyword list and delimiter character.
+// Use this function if you calling from within multiple goroutines.
+func HumanizeUsing(digest []byte, words int, keywords []string, delimiter string) (string, error) {
+	if len(keywords) != 256 {
+		return "", ErrIncorrectSizeList
+	}
+
+	var w []string
+
+	c, err := Compress(digest, words)
+	if err != nil {
+		return "", err
+	}
+
+	for _, b := range c {
+		w = append(w, keywords[b])
+	}
+
+	return strings.Join(w, delimiter), nil
+}

--- a/human_hash_test.go
+++ b/human_hash_test.go
@@ -3,6 +3,10 @@ package humanhash
 import (
 	"encoding/hex"
 	"fmt"
+	_ "log"
+	"sort"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -61,4 +65,67 @@ func TestHumanize(t *testing.T) {
 		}
 	}
 
+}
+
+// This test case only makes sense when run with "go test -race"
+func Test_HumanizeUsing(t *testing.T) {
+
+	// Use a reverse keywords list in one of the goroutines
+	reverseKeywords := make([]string, len(DefaultWordList))
+	copy(reverseKeywords, DefaultWordList)
+	sort.Sort(sort.Reverse(sort.StringSlice(reverseKeywords)))
+
+	// Use an uppercase keywords list in another of the goroutines
+	upperKeywords := make([]string, 0)
+	for _, w := range DefaultWordList {
+		upperKeywords = append(upperKeywords, strings.ToUpper(w))
+	}
+
+	fixtures := []struct {
+		input     []byte
+		result    string
+		keywords  []string
+		delimiter string
+	}{
+		{
+			input:     []byte{96, 173, 141, 13, 135, 27, 96, 149, 128, 130, 151},
+			result:    "delta_magazine_india_november",
+			keywords:  reverseKeywords,
+			delimiter: "_",
+		},
+		{
+			input:     []byte{0, 255, 141, 13},
+			result:    "ack-zulu-mississippi-august",
+			keywords:  DefaultWordList,
+			delimiter: "-",
+		},
+		{
+			input:     []byte{0, 255, 141, 13},
+			result:    "ACK.ZULU.MISSISSIPPI.AUGUST",
+			keywords:  upperKeywords,
+			delimiter: ".",
+		},
+	}
+
+	var wg sync.WaitGroup
+
+	for _, fixture := range fixtures {
+		wg.Add(1)
+
+		go func(input []byte, result string, keywords []string, delimiter string) {
+			defer wg.Done()
+
+			res, err := HumanizeUsing(input, 4, keywords, delimiter)
+			if err != nil {
+				t.Error(err)
+			}
+
+			//log.Printf("res %v", res)
+			if res != result {
+				t.Errorf("humanize didn't match expected=%s actual=%s", result, res)
+			}
+		}(fixture.input, fixture.result, fixture.keywords, fixture.delimiter)
+	}
+
+	wg.Wait()
 }

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package humanhash
 
 // Version the release version
-const Version = "1.0.1"
+const Version = "1.1.0"


### PR DESCRIPTION
I need to use Humanize from within multiple goroutines each with their own keyword list.
This pull request does this in a race condition safe manner.
Please refer to human_hash_test.go for a working example, which should be run using "go test -race"

Thanks.
